### PR TITLE
fix 'Cannot set properties of undefined'

### DIFF
--- a/src/missionary/impl/Ambiguous.cljs
+++ b/src/missionary/impl/Ambiguous.cljs
@@ -294,7 +294,7 @@
                     (if (nil? curr)
                       (ack p)
                       (when (instance? Processor curr)
-                        (let [pivot (.-child pr)]
+                        (let [pivot (.-child curr)]
                           (set! (.-current b) pivot)
                           (set! (.-parent pivot) b)
                           (loop [pr ^Processor curr]


### PR DESCRIPTION
Please review as I have no understanding of the code, but there was an obvious error in that the `pr` was undefined (it evaluated to cljs.core.pr, so hiding the problem), so I just replaced it with `curr` which seems to have fixed the error.

Addresses #77 but does not fix it completely, now getting:
```
 TypeError: Cannot read properties of null (reading 'next')
    at Object.missionary$impl$Ambiguous$walk [as walk] (Ambiguous.cljs:116:31)
    at Object.missionary$impl$Ambiguous$ready [as ready] (Ambiguous.cljs:312:49)
    at G__261264.G__261264__0 [as cljs$core$IFn$_invoke$arity$0] (Ambiguous.cljs:323:28)
    at missionary$impl$Watch$kill (Watch.cljs:22:32)
    at Object.eval [as cljs$core$IFn$_invoke$arity$0] (Watch.cljs:7:20)
    at Object.missionary$impl$Ambiguous$cancel [as cancel] (Ambiguous.cljs:92:9)
    at missionary$impl$Ambiguous$walk (Ambiguous.cljs:116:6)
    at missionary$impl$Ambiguous$kill (Ambiguous.cljs:85:6)
```


